### PR TITLE
Add NODE_PATH to use installed modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,4 +74,5 @@ RUN jupyter kernelspec list && \
     jupyter nbextension list
 
 ENV JDK_JAVA_OPTIONS -Xcomp -Xms2g -Xmx2g -XX:-PreserveFramePointer
+ENV NODE_PATH="/opt/conda/lib/node_modules/"
 USER $NB_USER

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,5 +74,5 @@ RUN jupyter kernelspec list && \
     jupyter nbextension list
 
 ENV JDK_JAVA_OPTIONS -Xcomp -Xms2g -Xmx2g -XX:-PreserveFramePointer
-ENV NODE_PATH="/opt/conda/lib/node_modules/"
+ENV NODE_PATH /opt/conda/lib/node_modules/
 USER $NB_USER


### PR DESCRIPTION
When creating a JS Notebook and stating: `const fetch = require("request");` it leads to an error `Error: Cannot find module 'request' at Function.Module._resolveFilename (internal/modules/cjs/loader.js:668:15)`. Same when shelling into the running instance. request is installed, just nodeJS doesn't seem to find it. After adding `NODE_PATH="/opt/conda/lib/node_modules/"` it works